### PR TITLE
Fix transcribe_bookmarks command

### DIFF
--- a/main_file.py
+++ b/main_file.py
@@ -540,7 +540,7 @@ class AudibleAPI:
                         worksheet.set_row(i, 100, cell_format)
 
                     # Apply changes and save xlsx to Transcribed bookmarks folder.
-                    writer.save()
+                    writer.close()
 
                     # post_notion(heading, r.recognize_google(audio))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,6 +52,7 @@ urllib3==1.26.9
 wavio==0.0.4
 wget==3.2
 wrapt==1.14.1
+xlsxwriter==3.1.2
 zerorpc==0.6.3
 zope.event==4.5.0
 zope.interface==5.4.0


### PR DESCRIPTION
- Add missing xlsxwriter dependency to fix `No module named xlsxwriter` error.
- Use `writer.close()` instead of `writer.save()` which has been removed in newer versions of pandas.