### PR TITLE
Fix URL for Australia, updated requirements file dependency versions

### DIFF
--- a/main_file.py
+++ b/main_file.py
@@ -17,7 +17,7 @@ country_code_mapping = {
     "us": ".com",
     "ca": ".ca",
     "uk": ".co.uk",
-    "au": ".co.au",
+    "au": ".com.au",
     "fr": ".fr",
     "de": ".de",
     "jp": ".co.jp",

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ dill==0.3.5.1
 ffmpeg-python==0.2.0
 future==0.18.2
 gevent==22.10.2
-greenlet==2.0.2
+greenlet==3.0.3
 h11==0.12.0
 httpcore==0.15.0
 httpx==0.23.0
@@ -21,7 +21,7 @@ isort==5.10.1
 lazy-object-proxy==1.7.1
 mccabe==0.7.0
 msgpack==1.0.4
-numpy==1.25.2
+numpy==1.26.1
 pandas==2.0.3
 pbkdf2==1.3
 pefile==2022.5.30
@@ -35,7 +35,7 @@ pydub==0.25.1
 pylint==2.14.4
 python-dateutil==2.8.2
 pytz==2023.3
-pyzmq==23.2.0
+pyzmq==26.0.3
 requests==2.28.0
 rfc3986==1.5.0
 rsa==4.8


### PR DESCRIPTION
Hey,
The URL for audible australia was wrong, and I was getting errors. Here is a fix.
Alongside, I updated the dependencies to the latest as well.